### PR TITLE
Adds GitHub Action Support, Fixes macOS FUSE Mount Errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           pushd C:\Qt
           git clone https://github.com/engnr/qt-downloader.git
           cd qt-downloader
-          python3.8 qt-downloader windows desktop 5.15.2 win64_msvc2019_64
+          python qt-downloader windows desktop 5.15.2 win64_msvc2019_64
           popd
           
       - name: Build Rclone Browser

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
           prepare: |
             /usr/sbin/pkg_add -vv pkgin
             pkgin update
-            pkgin -Vy install git cmake qt5-qtdeclarative MesaLib
+            pkgin -Vy install git cmake qt5-qtdeclarative graphics/MesaLib
             cd work/RcloneBrowser/RcloneBrowser
             mkdir build
             cd build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,7 @@ jobs:
         
       - uses: rickstaa/action-create-tag@v1
         with:
-          tag: ${{ env.SHORT_SHA }}
+          tag: release-${{ env.SHORT_SHA }}
           tag_exists_error: false
           
       - uses: ncipollo/release-action@v1
@@ -144,8 +144,7 @@ jobs:
           name: Rclone Browser Autobuild For Commit ${{ env.SHORT_SHA }}
           omitBody: true
           generateReleaseNotes: true
-          commit: ${{ env.SHORT_SHA }}
           prerelease: true
           skipIfReleaseExists: true
-          tag: ${{ env.SHORT_SHA }}
+          tag: release-${{ env.SHORT_SHA }}
         

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,28 +134,3 @@ jobs:
         with:
           name: openbsd
           path: build/build/*
-          
-  build_netbsd:
-    name: NetBSD Build
-    runs-on: macos-12
-    
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install Development Tools and Build Rclone Browser
-        uses: vmactions/netbsd-vm@v0
-        with:
-          mem: 4096
-          prepare: |
-            /usr/sbin/pkg_add -vv pkgin
-            pkgin update
-            pkgin -Vy install git cmake qt5-qtdeclarative qt5-qtmultimedia py39-OpenGL-3.1.5nb4
-            cd work/RcloneBrowser/RcloneBrowser
-            mkdir build
-            cd build
-            cmake .. -DCMAKE_PREFIX_PATH:PATH=/usr/pkg/qt5
-            make
-            
-      - uses: actions/upload-artifact@v3
-        with:
-          name: netbsd
-          path: build/build/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,8 @@ jobs:
         uses: vmactions/freebsd-vm@v0
         with:
           prepare: |
-            pkg install git cmake qt5-buildtools qt5-declarative qt5-multimedia qt5-qmake -y
+            env ASSUME_ALWAYS_YES=YES pkg update -f
+            env ASSUME_ALWAYS_YES=YES pkg install -y git cmake qt5-buildtools qt5-declarative qt5-multimedia qt5-qmake
             mkdir build
             cd build
             cmake ..
@@ -115,10 +116,10 @@ jobs:
         uses: vmactions/openbsd-vm@v0
         with:
           prepare: |
-            pkg_add git cmake qt5 -y
+            pkg_add -vv git cmake qt5
             mkdir build
             cd build
-            cmake .. -DCMAKE_PREFIX_PATH:PATH=/usr/local/lib/qt5/cmak
+            cmake .. -DCMAKE_PREFIX_PATH:PATH=/usr/local/lib/qt5/cmake
             make
             
       - uses: actions/upload-artifact@v3
@@ -136,7 +137,7 @@ jobs:
         uses: vmactions/netbsd-vm@v0
         with:
           prepare: |
-            pkgin install git cmake qt5-qtdeclarative qt5-qtmultimedia -y
+            /usr/sbin/pkg_add -vv git cmake qt5-qtdeclarative qt5-qtmultimedia -y
             mkdir build
             cd build
             cmake ..

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Compress artifacts
         run: |
           pushd /tmp/artifacts
-          for i in *;do zip -r -0 $i $i.zip;done
+          for i in *;do zip -r -0 $i.zip $i;done
           popd
           
       - name: Get short commit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,9 @@ jobs:
           mkdir C:\Qt
           pushd C:\Qt
           git clone https://github.com/engnr/qt-downloader.git
-          cd qt-downloader
-          python qt-downloader windows desktop 5.15.2 win64_msvc2019_64
+          mv qt-downloader/qt-downloader .\qtd
+          rm -f qt-downloader
+          python qtd windows desktop 5.15.2 win64_msvc2019_64
           popd
           
       - name: Build Rclone Browser

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,7 @@ jobs:
           path: build/build/*.zip
         
   build_freebsd:
+    name: FreeBSD Build
     runs-on: macos-12
     
     steps:
@@ -105,6 +106,7 @@ jobs:
           path: build/build/*
           
   build_openbsd:
+    name: OpenBSD Build
     runs-on: macos-12
     
     steps:
@@ -125,6 +127,7 @@ jobs:
           path: build/build/*
           
   build_netbsd:
+    name: NetBSD Build
     runs-on: macos-12
     
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,8 @@ jobs:
           
       - name: Build Rclone Browser
         run: |
+          mkdir build
+          cd build
           cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_PREFIX_PATH=C:\Qt\5.15.2\msvc2019_64 .. 
           cmake --build . --config Release
           C:\Qt\5.15.2\msvc2019_64\bin\windeployqt.exe --no-translations --no-angle --no-compiler-runtime --no-svg ".\build\Release\RcloneBrowser.exe"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,9 +93,12 @@ jobs:
       - name: Install Development Tools and Build Rclone Browser
         uses: vmactions/freebsd-vm@v0
         with:
+          mem: 4096
           prepare: |
             env ASSUME_ALWAYS_YES=YES pkg update -f
             env ASSUME_ALWAYS_YES=YES pkg install -y git cmake qt5-buildtools qt5-declarative qt5-multimedia qt5-qmake
+            pwd
+            cd work/RcloneBrowser/RcloneBrowser
             mkdir build
             cd build
             cmake ..
@@ -115,8 +118,11 @@ jobs:
       - name: Install Development Tools and Build Rclone Browser
         uses: vmactions/openbsd-vm@v0
         with:
+          mem: 4096
           prepare: |
             pkg_add -vv git cmake qt5
+            pwd
+            cd work/RcloneBrowser/RcloneBrowser
             mkdir build
             cd build
             cmake .. -DCMAKE_PREFIX_PATH:PATH=/usr/local/lib/qt5/cmake
@@ -136,8 +142,11 @@ jobs:
       - name: Install Development Tools and Build Rclone Browser
         uses: vmactions/netbsd-vm@v0
         with:
+          mem: 4096
           prepare: |
             /usr/sbin/pkg_add -vv git cmake qt5-qtdeclarative qt5-qtmultimedia -y
+            pwd
+            cd work/RcloneBrowser/RcloneBrowser
             mkdir build
             cd build
             cmake ..

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,10 @@ name: Build Rclone Browser
 
 on:
   push:
+    branches:
+      - main
+      - master
+      
   workflow_dispatch:
   
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
         uses: vmactions/freebsd-vm@v0
         with:
           prepare: |
-            sudo pkg install git cmake qt5-buildtools qt5-declarative qt5-multimedia qt5-qmake -y
+            pkg install git cmake qt5-buildtools qt5-declarative qt5-multimedia qt5-qmake -y
             mkdir build
             cd build
             cmake ..
@@ -115,7 +115,7 @@ jobs:
         uses: vmactions/openbsd-vm@v0
         with:
           prepare: |
-            sudo pkg_add git cmake qt5 -y
+            pkg_add git cmake qt5 -y
             mkdir build
             cd build
             cmake .. -DCMAKE_PREFIX_PATH:PATH=/usr/local/lib/qt5/cmak
@@ -136,7 +136,7 @@ jobs:
         uses: vmactions/netbsd-vm@v0
         with:
           prepare: |
-            sudo pkgin install git cmake qt5-qtdeclarative qt5-qtmultimedia -y
+            pkgin install git cmake qt5-qtdeclarative qt5-qtmultimedia -y
             mkdir build
             cd build
             cmake ..

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,13 +38,10 @@ jobs:
           cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_PREFIX_PATH=C:\Qt\5.15.2\msvc2019_64 .. 
           cmake --build . --config Release
           C:\Qt\5.15.2\msvc2019_64\bin\windeployqt.exe --no-translations --no-angle --no-compiler-runtime --no-svg ".\build\Release\RcloneBrowser.exe"
-          ls
-          ls .\build
-          ls .\build\Release
       - uses: actions/upload-artifact@v3
         with:
           name: windows
-          path: .\build\Release\RcloneBrowser.exe
+          path: build\build\Release\*
           
   build_linux:
     name: Linux Build
@@ -151,7 +148,7 @@ jobs:
           prepare: |
             /usr/sbin/pkg_add -vv pkgin
             pkgin update
-            pkgin -Vy install git cmake qt5-qtdeclarative
+            pkgin -Vy install git cmake qt5-qtdeclarative MesaLib
             cd work/RcloneBrowser/RcloneBrowser
             mkdir build
             cd build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,3 +134,34 @@ jobs:
         with:
           name: openbsd
           path: build/build/*
+
+  create_release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Create artifact directory
+        run: mkdir /tmp/artifacts
+      - uses: actions/download-artifact@v3
+        with:
+          path: /tmp/artifacts
+      - name: Compress artifacts
+        run: |
+          pushd /tmp/artifacts
+          for i in *;do zip -r -0 $i $i.zip;done
+          popd
+          
+      - name: Get short commit
+        run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+        
+      - uses: ncipollo/release-action@v1
+        with:
+          artifacts: "/tmp/artifacts/*.zip"
+          name: Rclone Browser Autobuild For Commit ${{ env.SHORT_SHA }}
+          omitBody: true
+          generateReleaseNotes: true
+          commit: ${{ env.SHORT_SHA }}
+          prerelease: true
+          skipIfReleaseExists: true
+          tag: ${{ env.SHORT_SHA }}
+        

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,6 +132,12 @@ jobs:
       - name: Get short commit
         run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
         
+      - uses: rickstaa/action-create-tag@v1
+        id: "tag_create"
+        with:
+          tag: ${{ env.SHORT_SHA }}
+          tag_exists_error: false
+          
       - uses: ncipollo/release-action@v1
         with:
           artifacts: "/tmp/artifacts/*.zip"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,7 @@ jobs:
     needs: [build_windows, build_linux, build_macos, build_freebsd]
     
     steps:
+      - uses: actions/checkout@v3
       - name: Create artifact directory
         run: mkdir /tmp/artifacts
       - uses: actions/download-artifact@v3
@@ -133,7 +134,6 @@ jobs:
         run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
         
       - uses: rickstaa/action-create-tag@v1
-        id: "tag_create"
         with:
           tag: ${{ env.SHORT_SHA }}
           tag_exists_error: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,6 +138,7 @@ jobs:
   create_release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    needs: [build_windows, build_linux, build_macos, build_freebsd, build_openbsd]
     
     steps:
       - name: Create artifact directory

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,12 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Development Tools
         run: |
-          choco install visualstudio2019community visualstudio2019-workload-nativedesktop cmake python38 qt5-default -y
+          choco install visualstudio2019community visualstudio2019-workload-nativedesktop cmake qt5-default -y
           curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
           refreshenv
-          python3.8 get-pip.py
+          python get-pip.py
           refreshenv
-          C:\Python38\Scripts\pip3.8.exe install py7zr lxml requests semantic-version
+          pip install py7zr lxml requests semantic-version
           mkdir C:\Qt
           pushd C:\Qt
           git clone https://github.com/engnr/qt-downloader.git

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
           prepare: |
             /usr/sbin/pkg_add -vv pkgin
             pkgin update
-            pkgin install -V -y git cmake qt5-qtdeclarative
+            pkgin -Vy install git cmake qt5-qtdeclarative
             cd work/RcloneBrowser/RcloneBrowser
             mkdir build
             cd build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,68 @@
+name: Build Rclone Browser
+
+on:
+  push:
+  workflow_dispatch:
+  
+jobs:
+  build_windows:
+    name: Windows Build
+    runs-on: windows-latest
+    
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Development Tools
+        run: choco install visualstudio2019community visualstudio2019-workload-nativedesktop cmake qt5-default -y 
+      - name: Build Rclone Browser
+        run: |
+          cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_PREFIX_PATH=c:\Qt\5.15.2\msvc2017_64 .. 
+          cmake --build . --config Release
+          C:\Qt\5.15.2\msvc2017_64\bin\windeployqt.exe --no-translations --no-angle --no-compiler-runtime --no-svg ".\build\Release\RcloneBrowser.exe"
+      - uses: actions/upload-artifact@v3
+        with:
+          name: RcloneBrowser.exe
+          path: .\build\Release\RcloneBrowser.exe
+          
+  build_linux:
+    name: Linux Build
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Development Tools
+        run: |
+          sudo apt update
+          sudo apt -y install git g++ cmake make qtdeclarative5-dev qtmultimedia5-dev
+      - name: Build Rclone Browser
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          make -j $(nproc)
+          ### TODO: Upload the artifact when we know where it lives
+          ls
+         
+  build_macos:
+    name: macOS Build
+    runs-on: macos-latest
+    
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Development Tools
+        run: brew install git cmake rclone qt5
+      - name: 
+        run: |
+          mkdir build
+          cd build
+          cmake .. -DCMAKE_PREFIX_PATH:PATH=/usr/local/opt/qt5
+          make -j $(nproc)
+          cd build
+          /usr/local/opt/qt@5/bin/macdeployqt rclone-browser.app -executable="rclone-browser.app/Contents/MacOS/rclone-browser" -qmldir=../src/
+          mv rclone-browser.app Rclone\ Browser.app
+          zip -r -0 Rclone\ Browser.zip Rclone\ Browser.app
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Rclone Browser (macOS)
+          path: build/build/*.zip
+        
+    

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
           cmake ..
           make -j $(nproc)
           ### TODO: Upload the artifact when we know where it lives
-          ls
+          ls build
          
   build_macos:
     name: macOS Build
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Development Tools
         run: brew install git cmake rclone qt5
-      - name: 
+      - name: Build Rclone Browser
         run: |
           mkdir build
           cd build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
          name: linux
-         path: build/build/rclone-browser
+         path: build/build/*
          
   build_macos:
     name: macOS Build
@@ -84,4 +84,62 @@ jobs:
           name: macos
           path: build/build/*.zip
         
+  build_freebsd:
+    runs-on: macos-12
     
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Development Tools and Build Rclone Browser
+        uses: vmactions/freebsd_vm@v0
+        with:
+          prepare: |
+            sudo pkg install git cmake qt5-buildtools qt5-declarative qt5-multimedia qt5-qmake -y
+            mkdir build
+            cd build
+            cmake ..
+            make
+            
+      - uses: actions/upload-artifact@v3
+        with:
+          name: freebsd
+          path: build/build/*
+          
+  build_openbsd:
+    runs-on: macos-12
+    
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Development Tools and Build Rclone Browser
+        uses: vmactions/freebsd_vm@v0
+        with:
+          prepare: |
+            sudo pkg_add git cmake qt5 -y
+            mkdir build
+            cd build
+            cmake .. -DCMAKE_PREFIX_PATH:PATH=/usr/local/lib/qt5/cmak
+            make
+            
+      - uses: actions/upload-artifact@v3
+        with:
+          name: openbsd
+          path: build/build/*
+          
+  build_netbsd:
+    runs-on: macos-12
+    
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Development Tools and Build Rclone Browser
+        uses: vmactions/freebsd_vm@v0
+        with:
+          prepare: |
+            sudo pkgin install git cmake qt5-qtdeclarative qt5-qtmultimedia -y
+            mkdir build
+            cd build
+            cmake ..
+            make
+            
+      - uses: actions/upload-artifact@v3
+        with:
+          name: netbsd
+          path: build/build/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,12 @@ jobs:
         run: choco install visualstudio2019community visualstudio2019-workload-nativedesktop cmake qt5-default -y 
       - name: Build Rclone Browser
         run: |
-          cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_PREFIX_PATH=c:\Qt\5.15.2\msvc2017_64 .. 
+          cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_PREFIX_PATH=C:\Qt\5.15.2 .. 
           cmake --build . --config Release
-          C:\Qt\5.15.2\msvc2017_64\bin\windeployqt.exe --no-translations --no-angle --no-compiler-runtime --no-svg ".\build\Release\RcloneBrowser.exe"
+          C:\Qt\5.15.2\bin\windeployqt.exe --no-translations --no-angle --no-compiler-runtime --no-svg ".\build\Release\RcloneBrowser.exe"
       - uses: actions/upload-artifact@v3
         with:
-          name: RcloneBrowser.exe
+          name: Rclone Browser (Windows)
           path: .\build\Release\RcloneBrowser.exe
           
   build_linux:
@@ -39,8 +39,11 @@ jobs:
           cd build
           cmake ..
           make -j $(nproc)
-          ### TODO: Upload the artifact when we know where it lives
-          ls build
+          
+      - uses: actions/upload-artifact@v3
+        with:
+         name: Rclone Browser (Linux)
+         path: build/build/rclone-browser
          
   build_macos:
     name: macOS Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           pushd C:\Qt
           git clone https://github.com/engnr/qt-downloader.git
           mv qt-downloader/qt-downloader .\qtd
-          rm -f qt-downloader
+          Remove-Item -Recurse -Force qt-downloader
           python qtd windows desktop 5.15.2 win64_msvc2019_64
           popd
           
@@ -34,7 +34,7 @@ jobs:
           C:\Qt\5.15.2\msvc2019_64\bin\windeployqt.exe --no-translations --no-angle --no-compiler-runtime --no-svg ".\build\Release\RcloneBrowser.exe"
       - uses: actions/upload-artifact@v3
         with:
-          name: Rclone Browser (Windows)
+          name: windows
           path: .\build\Release\RcloneBrowser.exe
           
   build_linux:
@@ -56,7 +56,7 @@ jobs:
           
       - uses: actions/upload-artifact@v3
         with:
-         name: Rclone Browser (Linux)
+         name: linux
          path: build/build/rclone-browser
          
   build_macos:
@@ -79,7 +79,7 @@ jobs:
           zip -r -0 Rclone\ Browser.zip Rclone\ Browser.app
       - uses: actions/upload-artifact@v3
         with:
-          name: Rclone Browser (macOS)
+          name: macos
           path: build/build/*.zip
         
     

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,11 +82,10 @@ jobs:
           cd build
           /usr/local/opt/qt@5/bin/macdeployqt rclone-browser.app -executable="rclone-browser.app/Contents/MacOS/rclone-browser" -qmldir=../src/
           mv rclone-browser.app Rclone\ Browser.app
-          zip -r -0 Rclone\ Browser.zip Rclone\ Browser.app
       - uses: actions/upload-artifact@v3
         with:
           name: macos
-          path: build/build/*.zip
+          path: build/build/*
         
   build_freebsd:
     name: FreeBSD Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
         with:
           mem: 4096
           prepare: |
-            /usr/sbin/pkg_add -vv git cmake qt5-qtdeclarative qt5-qtmultimedia -y
+            /usr/sbin/pkg_add -vv git cmake qt5-*
             pwd
             cd work/RcloneBrowser/RcloneBrowser
             mkdir build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
           prepare: |
             /usr/sbin/pkg_add -vv pkgin
             pkgin update
-            pkgin -Vy install git cmake qt5-qtdeclarative graphics/MesaLib
+            pkgin -Vy install git cmake qt5-qtdeclarative qt5-qtmultimedia
             cd work/RcloneBrowser/RcloneBrowser
             mkdir build
             cd build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,9 @@ jobs:
           cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_PREFIX_PATH=C:\Qt\5.15.2\msvc2019_64 .. 
           cmake --build . --config Release
           C:\Qt\5.15.2\msvc2019_64\bin\windeployqt.exe --no-translations --no-angle --no-compiler-runtime --no-svg ".\build\Release\RcloneBrowser.exe"
+          ls
+          ls .\build
+          ls .\build\Release
       - uses: actions/upload-artifact@v3
         with:
           name: windows

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
           python get-pip.py
           refreshenv
           pip install py7zr lxml requests semantic-version
+          Remove-Item -Recurse -Force C:\Qt
           mkdir C:\Qt
           pushd C:\Qt
           git clone https://github.com/engnr/qt-downloader.git
@@ -119,7 +120,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Create artifact directory
-        run: mkdir /tmp/artifacts
+        run: rm -rf /tmp/artifacts && mkdir /tmp/artifacts
       - uses: actions/download-artifact@v3
         with:
           path: /tmp/artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,25 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Development Tools
-        run: choco install visualstudio2019community visualstudio2019-workload-nativedesktop cmake qt5-default -y 
+        run: |
+          choco install visualstudio2019community visualstudio2019-workload-nativedesktop cmake python38 qt5-default -y
+          curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+          refreshenv
+          python3.8 get-pip.py
+          refreshenv
+          C:\Python38\Scripts\pip3.8.exe install py7zr lxml requests semantic-version
+          mkdir C:\Qt
+          pushd C:\Qt
+          git clone https://github.com/engnr/qt-downloader.git
+          cd qt-downloader
+          python3.8 qt-downloader windows desktop 5.15.2 win64_msvc2019_64
+          popd
+          
       - name: Build Rclone Browser
         run: |
-          cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_PREFIX_PATH=C:\Qt\5.15.2 .. 
+          cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_PREFIX_PATH=C:\Qt\5.15.2\msvc2019_64 .. 
           cmake --build . --config Release
-          C:\Qt\5.15.2\bin\windeployqt.exe --no-translations --no-angle --no-compiler-runtime --no-svg ".\build\Release\RcloneBrowser.exe"
+          C:\Qt\5.15.2\msvc2019_64\bin\windeployqt.exe --no-translations --no-angle --no-compiler-runtime --no-svg ".\build\Release\RcloneBrowser.exe"
       - uses: actions/upload-artifact@v3
         with:
           name: Rclone Browser (Windows)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,34 +111,11 @@ jobs:
         with:
           name: freebsd
           path: build/build/*
-          
-  build_openbsd:
-    name: OpenBSD Build
-    runs-on: macos-12
-    
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install Development Tools and Build Rclone Browser
-        uses: vmactions/openbsd-vm@v0
-        with:
-          mem: 4096
-          prepare: |
-            pkg_add -vv git cmake qt5
-            cd work/RcloneBrowser/RcloneBrowser
-            mkdir build
-            cd build
-            cmake .. -DCMAKE_PREFIX_PATH:PATH=/usr/local/lib/qt5/cmake
-            make
-            
-      - uses: actions/upload-artifact@v3
-        with:
-          name: openbsd
-          path: build/build/*
 
   create_release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [build_windows, build_linux, build_macos, build_freebsd, build_openbsd]
+    needs: [build_windows, build_linux, build_macos, build_freebsd]
     
     steps:
       - name: Create artifact directory

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,6 @@ jobs:
           prepare: |
             env ASSUME_ALWAYS_YES=YES pkg update -f
             env ASSUME_ALWAYS_YES=YES pkg install -y git cmake qt5-buildtools qt5-declarative qt5-multimedia qt5-qmake
-            pwd
             cd work/RcloneBrowser/RcloneBrowser
             mkdir build
             cd build
@@ -125,7 +124,6 @@ jobs:
           mem: 4096
           prepare: |
             pkg_add -vv git cmake qt5
-            pwd
             cd work/RcloneBrowser/RcloneBrowser
             mkdir build
             cd build
@@ -148,12 +146,13 @@ jobs:
         with:
           mem: 4096
           prepare: |
-            /usr/sbin/pkg_add -vv git cmake qt5-*
-            pwd
+            /usr/sbin/pkg_add -vv pkgin
+            pkgin update
+            pkgin install -V -y git cmake qt5-qtdeclarative
             cd work/RcloneBrowser/RcloneBrowser
             mkdir build
             cd build
-            cmake ..
+            cmake .. -DCMAKE_PREFIX_PATH:PATH=/usr/pkg/qt5
             make
             
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
           prepare: |
             /usr/sbin/pkg_add -vv pkgin
             pkgin update
-            pkgin -Vy install git cmake qt5-qtdeclarative qt5-qtmultimedia
+            pkgin -Vy install git cmake qt5-qtdeclarative qt5-qtmultimedia py39-OpenGL-3.1.5nb4
             cd work/RcloneBrowser/RcloneBrowser
             mkdir build
             cd build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Development Tools and Build Rclone Browser
-        uses: vmactions/freebsd_vm@v0
+        uses: vmactions/freebsd-vm@v0
         with:
           prepare: |
             sudo pkg install git cmake qt5-buildtools qt5-declarative qt5-multimedia qt5-qmake -y
@@ -112,7 +112,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Development Tools and Build Rclone Browser
-        uses: vmactions/freebsd_vm@v0
+        uses: vmactions/openbsd-vm@v0
         with:
           prepare: |
             sudo pkg_add git cmake qt5 -y
@@ -133,7 +133,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Development Tools and Build Rclone Browser
-        uses: vmactions/freebsd_vm@v0
+        uses: vmactions/netbsd-vm@v0
         with:
           prepare: |
             sudo pkgin install git cmake qt5-qtdeclarative qt5-qtmultimedia -y

--- a/src/remote_widget.cpp
+++ b/src/remote_widget.cpp
@@ -1424,7 +1424,7 @@ RemoteWidget::RemoteWidget(IconCache *iconCache, const QString &remote,
 #if defined(Q_OS_MACOS)
       // on macOS we check if FUSE for macOS is installed
 
-      const QFileInfo outputDir("/Library/Filesystems/osxfuse.fs/");
+      const QFileInfo outputDir("/Library/Filesystems/macfuse.fs/");
 
       if (outputDir.exists()) {
 


### PR DESCRIPTION
This PR adds GitHub Actions support, which includes Windows, Linux, macOS, and FreeBSD Builds. It also adds support for automatically publishing releases. 

You will need to turn on write access for GitHub actions in this repo.