### PR TITLE
(AI) Upgrade to Qt 6 and Visual Studio 2022, enhance build configurat…

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 version: '#{build}'
-image: 'Visual Studio 2019'
+image: 'Visual Studio 2022'
 branches:
   only:
   - master
@@ -7,20 +7,18 @@ branches:
 skip_tags: true
 clone_depth: 1
 
+# Qt 6 no longer ships 32-bit Windows desktop kits, so only x64 is built.
+# Adjust QT_DIR to match the Qt 6 version available on the AppVeyor image.
 environment:
+  QT_DIR: C:\Qt\6.11.1\msvc2022_64
   matrix:
    - configuration: x64
      BUILD_ARCH: x64
-     BUILD_MSVC: msvc2017_64
-
-   - configuration: Win32
-     BUILD_ARCH: Win32
-     BUILD_MSVC: msvc2017
 
 build_script:
   - mkdir build
   - cd build
-  - cmake -G "Visual Studio 16 2019" -A %BUILD_ARCH% -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_PREFIX_PATH=C:\Qt\5.14\%BUILD_MSVC% ..
+  - cmake -G "Visual Studio 17 2022" -A %BUILD_ARCH% -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_PREFIX_PATH=%QT_DIR% ..
   - cmake --build . --config Release
 
 artifacts:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
   
 jobs:
   build_windows:
-    name: Windows Build
+    name: Windows Build (x64)
     runs-on: windows-latest
     
     steps:
@@ -18,20 +18,58 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: '5.15.2'
+          version: '6.11.1'
           host: 'windows'
           target: 'desktop'
-          arch: 'win64_msvc2019_64'
+          arch: 'win64_msvc2022_64'
+          modules: 'qtmultimedia'
       - name: Build Rclone Browser
         run: |
           mkdir build
           cd build
-          cmake -G "Visual Studio 18 2026" -A x64 -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_PREFIX_PATH="$env:QT_ROOT_DIR" ..
+          cmake -G "Visual Studio 17 2022" -A x64 -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_PREFIX_PATH="$env:QT_ROOT_DIR" ..
           cmake --build . --config Release
-          & "$env:QT_ROOT_DIR\bin\windeployqt.exe" --no-translations --no-angle --no-compiler-runtime --no-svg ".\build\Release\RcloneBrowser.exe"
+          & "$env:QT_ROOT_DIR\bin\windeployqt.exe" --no-translations --no-compiler-runtime --no-svg ".\build\Release\RcloneBrowser.exe"
       - uses: actions/upload-artifact@v4
         with:
           name: windows
+          path: build\build\Release\*
+
+  build_windows_arm64:
+    name: Windows Build (ARM64)
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Qt (host x64 tools)
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: '6.11.1'
+          host: 'windows'
+          target: 'desktop'
+          arch: 'win64_msvc2022_64'
+          modules: 'qtmultimedia'
+      - name: Install Qt (ARM64 target)
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: '6.11.1'
+          host: 'windows'
+          target: 'desktop'
+          arch: 'win64_msvc2022_arm64'
+          modules: 'qtmultimedia'
+      - name: Build Rclone Browser
+        shell: pwsh
+        run: |
+          $qtArm64 = "${env:RUNNER_WORKSPACE}\Qt\6.11.1\msvc2022_arm64"
+          mkdir build
+          cd build
+          cmake -G "Visual Studio 17 2022" -A ARM64 -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_PREFIX_PATH="$qtArm64" ..
+          cmake --build . --config Release
+          # windeployqt from the ARM64 kit deploys the matching ARM64 Qt DLLs.
+          & "$qtArm64\bin\windeployqt.exe" --no-translations --no-compiler-runtime --no-svg ".\build\Release\RcloneBrowser.exe"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-arm64
           path: build\build\Release\*
           
   build_linux:
@@ -43,7 +81,7 @@ jobs:
       - name: Install Development Tools
         run: |
           sudo apt update
-          sudo apt -y install git g++ cmake make qtdeclarative5-dev qtmultimedia5-dev
+          sudo apt -y install git g++ cmake make qt6-base-dev qt6-multimedia-dev libgl1-mesa-dev
       - name: Build Rclone Browser
         run: |
           mkdir build
@@ -57,7 +95,7 @@ jobs:
          path: build/build/*
          
   build_macos:
-    name: macOS Build
+    name: macOS Build (Apple Silicon)
     runs-on: macos-latest
     
     steps:
@@ -65,22 +103,20 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: '5.15.2'
+          version: '6.11.1'
           host: 'mac'
           target: 'desktop'
-          arch: 'clang_64'
+          arch: 'clang_arm64'
+          modules: 'qtmultimedia'
       - name: Build Rclone Browser
         run: |
           mkdir build
           cd build
-          # Qt 5.15.2 open-source binaries are x86_64 only (no native arm64 build
-          # exists for open-source 5.15.x), while macos-latest runners are Apple
-          # Silicon. Force an x86_64 build so it links against the Qt frameworks;
-          # the result runs natively on Intel and via Rosetta 2 on Apple Silicon.
-          cmake .. -DCMAKE_PREFIX_PATH="$QT_ROOT_DIR" -DCMAKE_OSX_ARCHITECTURES=x86_64
+          # macos-latest runners are Apple Silicon; build natively for arm64.
+          cmake .. -DCMAKE_PREFIX_PATH="$QT_ROOT_DIR" -DCMAKE_OSX_ARCHITECTURES=arm64
           make -j $(sysctl -n hw.ncpu)
           cd build
-          "$QT_ROOT_DIR/bin/macdeployqt" rclone-browser.app -executable="rclone-browser.app/Contents/MacOS/rclone-browser" -qmldir=../src/
+          "$QT_ROOT_DIR/bin/macdeployqt" rclone-browser.app -executable="rclone-browser.app/Contents/MacOS/rclone-browser"
           mv rclone-browser.app Rclone\ Browser.app
       - uses: actions/upload-artifact@v4
         with:
@@ -100,7 +136,7 @@ jobs:
           usesh: true
           prepare: |
             env ASSUME_ALWAYS_YES=YES pkg update -f
-            env ASSUME_ALWAYS_YES=YES pkg install -y git cmake qt5-buildtools qt5-declarative qt5-multimedia qt5-qmake
+            env ASSUME_ALWAYS_YES=YES pkg install -y git cmake qt6-base qt6-multimedia
           run: |
             mkdir build
             cd build
@@ -115,7 +151,7 @@ jobs:
   create_release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [build_windows, build_linux, build_macos, build_freebsd]
+    needs: [build_windows, build_windows_arm64, build_linux, build_macos, build_freebsd]
     
     steps:
       - uses: actions/checkout@v4

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,13 @@ matrix:
     - os: linux
       language: cpp
       sudo: false
-      dist: bionic
+      dist: jammy
       addons:
         apt:
           packages:
-            - qttools5-dev
-            - qtmultimedia5-dev
+            - qt6-base-dev
+            - qt6-multimedia-dev
+            - libgl1-mesa-dev
 
       script:
         - mkdir build && cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,15 @@ endif()
 
 project(rclone-browser)
 
-find_package(Qt5Widgets REQUIRED)
-if(WIN32)
-  find_package(Qt5WinExtras REQUIRED)
-elseif(APPLE)
-  find_package(Qt5MacExtras REQUIRED)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets Network)
+# Multimedia is only used for the optional finished-transfer notification
+# sound. Treat it as optional so the app still builds with Qt kits that do not
+# ship the Multimedia module.
+find_package(Qt6 QUIET OPTIONAL_COMPONENTS Multimedia)
+if(APPLE)
   find_library(COCOA_LIB Cocoa REQUIRED)
   find_library(IOKKIT_LIB IOKit REQUIRED)
 endif()

--- a/README.md
+++ b/README.md
@@ -154,11 +154,11 @@ Build instructions
 
 ### Linux
 1.  Install dependencies for your particular distribution:
-    *   **Debian/Ubuntu and derivatives**: `sudo apt update && sudo apt -y install git g++ cmake make qtdeclarative5-dev qtmultimedia5-dev`
-    *   **Suse/OpenSuse**: `sudo zypper ref && sudo zypper --non-interactive install git cmake make gcc-c++ libQt5Core-devel libQt5Widgets-devel libQt5Network-devel libqt5-qtmultimedia-devel`
-    *   **RHEL/CentOS**: `sudo yum -y install git gcc-c++ cmake make qt5-qtdeclarative qt5-qtmultimedia-devel`
-    *   **Fedora**: `sudo dnf -y install git g++ cmake make qt5-qtdeclarative-devel qt5-qtmultimedia-devel`
-    *   **Arch/Manjaro**: `sudo pacman -Sy --noconfirm --needed git gcc cmake make qt5-declarative qt5-multimedia`
+    *   **Debian/Ubuntu and derivatives**: `sudo apt update && sudo apt -y install git g++ cmake make qt6-base-dev qt6-multimedia-dev libgl1-mesa-dev`
+    *   **Suse/OpenSuse**: `sudo zypper ref && sudo zypper --non-interactive install git cmake make gcc-c++ qt6-base-devel qt6-multimedia-devel`
+    *   **RHEL/CentOS**: `sudo yum -y install git gcc-c++ cmake make qt6-qtbase-devel qt6-qtmultimedia-devel`
+    *   **Fedora**: `sudo dnf -y install git g++ cmake make qt6-qtbase-devel qt6-qtmultimedia-devel`
+    *   **Arch/Manjaro**: `sudo pacman -Sy --noconfirm --needed git gcc cmake make qt6-base qt6-multimedia`
 2.  Clone source code from this repo `git clone https://github.com/kapitainsky/RcloneBrowser.git`
 3.  Go to source folder `cd RcloneBrowser`
 4.  Create new build folder - `mkdir build && cd build`
@@ -167,7 +167,7 @@ Build instructions
 7.  Install `sudo make install`
 
 ### FreeBSD
-1.  Install dependencies `sudo pkg install git cmake qt5-buildtools qt5-declarative qt5-multimedia qt5-qmake`
+1.  Install dependencies `sudo pkg install git cmake qt6-base qt6-multimedia`
 2.  Clone source code from this repo `git clone https://github.com/kapitainsky/RcloneBrowser.git`
 3.  Go to source folder `cd RcloneBrowser`
 4.  Create new build folder - `mkdir build && cd build`
@@ -178,22 +178,22 @@ Build instructions
 *Note: For rclone remotes mount to work please see this forum [thread](https://forum.rclone.org/t/failed-to-mount-fuse-fs-freebsd/7723/9). For me it was enough to run `sudo sysctl vfs.usermount=1`*
 
 ### OpenBSD
-1.  Install dependencies `sudo pkg_add git cmake qt5`
+1.  Install dependencies `sudo pkg_add git cmake qt6`
 2.  Clone source code from this repo `git clone https://github.com/kapitainsky/RcloneBrowser.git`
 3.  Go to source folder `cd RcloneBrowser`
 4.  Create new build folder - `mkdir build && cd build`
-5.  Run `cmake .. -DCMAKE_PREFIX_PATH:PATH=/usr/local/lib/qt5/cmake` from build folder to create makefile
+5.  Run `cmake .. -DCMAKE_PREFIX_PATH:PATH=/usr/local/lib/qt6/cmake` from build folder to create makefile
 6.  Run `make` from build folder to create binary
 7.  Install `sudo make install`
 
 *Note: rclone for openBSD does not support `mount` hence this feature is disabled in Rclone Browser. cgofuse guys did not manage to implement it: [#18][billziss-gh_cgofuse_i18]*
 
 ### NetBSD
-1.  Install dependencies `sudo pkgin install git cmake qt5-qtdeclarative qt5-qtmultimedia`
+1.  Install dependencies `sudo pkgin install git cmake qt6-qtbase qt6-qtmultimedia`
 2.  Clone source code from this repo `git clone https://github.com/kapitainsky/RcloneBrowser.git`
 3.  Go to source folder `cd RcloneBrowser`
 4.  Create new build folder - `mkdir build && cd build`
-5.  Run `cmake .. -DCMAKE_PREFIX_PATH:PATH=/usr/pkg/qt5` from build folder to create makefile
+5.  Run `cmake .. -DCMAKE_PREFIX_PATH:PATH=/usr/pkg/qt6` from build folder to create makefile
 6.  Run `make` from build folder to create binary
 7.  Install `sudo make install`
 
@@ -202,43 +202,48 @@ Build instructions
 ### macOS
 1.  If you don't have [Homebrew](https://brew.sh/) yet install it `/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
 2.  You might be asked to install xcode command line tools - do it. This is actuall macOS SDK, headers, and build tools. You don't need full xcode IDE.
-3.  Install dependencies `brew install git cmake rclone qt5`
+3.  Install dependencies `brew install git cmake rclone qt` (Homebrew's `qt` formula is Qt 6, and builds natively for Apple Silicon and Intel)
 4.  Clone source code from this repo `git clone https://github.com/kapitainsky/RcloneBrowser.git`
 5.  Go to source folder `cd RcloneBrowser`
 6.  Create new build folder - `mkdir build && cd build`
-7.  Run `cmake .. -DCMAKE_PREFIX_PATH:PATH=/usr/local/opt/qt` from build folder to create makefile
+7.  Run `cmake .. -DCMAKE_PREFIX_PATH:PATH="$(brew --prefix qt)"` from build folder to create makefile (on Apple Silicon this is `/opt/homebrew/opt/qt`, on Intel `/usr/local/opt/qt`)
 8.  Run `make` from build folder to create binary
 9.  Go to yet another newly created build folder `cd build`. Your binary should be here
-10. Package your binary with Qt libraries to create self contained application `/usr/local/opt/qt/bin/macdeployqt rclone-browser.app -executable="rclone-browser.app/Contents/MacOS/rclone-browser" -qmldir=../src/`. Without this step binary won't work without Qt installed
+10. Package your binary with Qt libraries to create self contained application `"$(brew --prefix qt)"/bin/macdeployqt rclone-browser.app -executable="rclone-browser.app/Contents/MacOS/rclone-browser"`. Without this step binary won't work without Qt installed
 
 ### Windows
-1.  Install [Visual Studio 2019][8], [Visual Studio 2022](https://learn.microsoft.com/en-us/visualstudio/releases/2022/release-notes), or Visual Studio 2026 - you only need the **Desktop development with C++** workload
+1.  Install [Visual Studio 2022](https://learn.microsoft.com/en-us/visualstudio/releases/2022/release-notes) or Visual Studio 2026 - you only need the **Desktop development with C++** workload. For a native Windows on ARM build also add the **ARM64 build tools** component.
 2.  Install [CMake][9] 3.16 or newer (CMake 4.x is supported)
-3.  Install Qt 5.15.x (64-bit) from the [Qt website][10]. Select **MSVC 2019 64-bit** prebuilt components (`msvc2019_64`). This kit works with Visual Studio 2019 and newer. The steps below assume Qt is installed in `c:\Qt\5.15.2`
+3.  Install Qt 6.11.x from the [Qt website][10]. Select the **MSVC 2022 64-bit** prebuilt component (`msvc2022_64`), and optionally **Qt Multimedia** (only needed for the finished-transfer notification sound). For native Windows on ARM also install the **MSVC 2022 ARM64** kit (`msvc2022_arm64`). The steps below assume Qt is installed in `c:\Qt\6.11.1`
 4.  Get Rclone Browser source code - clone this repo with git or download a zip from [releases][3]
 5.  Open a **Developer Command Prompt for VS** (or any shell where `cmake` and the MSVC compiler are on `PATH`), then go to the source folder: `cd RcloneBrowser`
 6.  Create a build folder: `mkdir build` and `cd build`
 7.  Configure and build. Replace the `-G` value with the generator matching your Visual Studio version (run `cmake --help` to list installed generators):
 
-    * Visual Studio 2019: `"Visual Studio 16 2019"`
     * Visual Studio 2022: `"Visual Studio 17 2022"`
     * Visual Studio 2026: `"Visual Studio 18 2026"`
 
-    Example for 64-bit Release with Visual Studio 2026:
+    Example for 64-bit Release with Visual Studio 2022:
 
-    `cmake -G "Visual Studio 18 2026" -A x64 -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_PREFIX_PATH=c:\Qt\5.15.2\msvc2019_64 .. && cmake --build . --config Release`
+    `cmake -G "Visual Studio 17 2022" -A x64 -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_PREFIX_PATH=c:\Qt\6.11.1\msvc2022_64 .. && cmake --build . --config Release`
 
-8.  Bundle Qt libraries with [windeployqt](https://doc.qt.io/qt-5/windows-deployment.html). Run this from the **build** folder (note the double `build` in the path - that is intentional):
+    For a native Windows on ARM (ARM64) build, use the ARM64 kit and architecture:
 
-    `c:\Qt\5.15.2\msvc2019_64\bin\windeployqt.exe --no-translations --no-angle --no-compiler-runtime --no-svg ".\build\Release\RcloneBrowser.exe"`
+    `cmake -G "Visual Studio 17 2022" -A ARM64 -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_PREFIX_PATH=c:\Qt\6.11.1\msvc2022_arm64 .. && cmake --build . --config Release`
 
-    windeployqt should report `64 bit, release executable` and copy release DLLs such as `Qt5Core.dll` (not `Qt5Cored.dll`). If you see debug DLL names, the executable path or build configuration is wrong - do not rename debug DLLs to work around this.
+8.  Bundle Qt libraries with [windeployqt](https://doc.qt.io/qt-6/windows-deployment.html). Run this from the **build** folder (note the double `build` in the path - that is intentional):
+
+    `c:\Qt\6.11.1\msvc2022_64\bin\windeployqt.exe --no-translations --no-compiler-runtime --no-svg ".\build\Release\RcloneBrowser.exe"`
+
+    windeployqt should copy release DLLs such as `Qt6Core.dll` (not `Qt6Cored.dll`). If you see debug DLL names, the executable path or build configuration is wrong - do not rename debug DLLs to work around this. (The old `--no-angle` flag is gone in Qt 6.)
 
 9.  The runnable application is in `build\build\Release\` - `RcloneBrowser.exe` plus the Qt DLLs and plugin folders copied by windeployqt
 
 10. Because `--no-compiler-runtime` is used, target machines also need the matching [Microsoft Visual C++ Redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist) for the Visual Studio version you built with.
 
-*Optional:* `scripts\release_windows.cmd x64` automates a full release build (windeployqt, MSVC runtime DLLs, zip, and installer) when run from a configured release environment.
+*Optional:* `scripts\release_windows.cmd x64` (or `arm64`) automates a full release build (windeployqt, MSVC runtime DLLs, zip, and installer) when run from a configured release environment.
+
+> **Note:** Qt 6 no longer provides 32-bit Windows desktop kits, so 32-bit Windows builds are no longer supported.
 
 Portable vs standard mode
 -----------------------

--- a/assets/rclone-browser.appdata.xml
+++ b/assets/rclone-browser.appdata.xml
@@ -7,7 +7,7 @@
   <name>Rclone Browser</name>
   <summary>Simple cross platfrom GUI for rclone command line</summary>
   <description>
-    <p>Rclone Browser is a cross-platform Qt5 GUI for Rclone, a command line tool to synchronize (and mount) files from remote cloud storage services like Google Drive, OneDrive, Nextcloud, Dropbox, Amazon Drive and S3, Mega, and others. Use it to copy a file from one cloud storage service to another, from a cloud storage to your system or the other way around, and to mount some cloud storage on your system with a single click.</p>
+    <p>Rclone Browser is a cross-platform Qt 6 GUI for Rclone, a command line tool to synchronize (and mount) files from remote cloud storage services like Google Drive, OneDrive, Nextcloud, Dropbox, Amazon Drive and S3, Mega, and others. Use it to copy a file from one cloud storage service to another, from a cloud storage to your system or the other way around, and to mount some cloud storage on your system with a single click.</p>
     <p> - Allows to browse and modify any rclone remote, including encrypted ones</p>
     <p> - Uses same configuration file as rclone, no extra configuration required</p>
     <p> - Supports custom location and encryption for .rclone.conf configuration file</p>

--- a/scripts/rclone-browser-win-installer.iss
+++ b/scripts/rclone-browser-win-installer.iss
@@ -32,13 +32,16 @@ SolidCompression=yes
 WizardStyle=modern
 
 #if MyAppArch=="x64"
-; "ArchitecturesAllowed=x64" specifies that Setup cannot run on
-; anything but x64.
-ArchitecturesAllowed=x64
-; "ArchitecturesInstallIn64BitMode=x64" requests that the install be
-; done in "64-bit mode" on x64, meaning it should use the native
-; 64-bit Program Files directory and the 64-bit view of the registry.
-ArchitecturesInstallIn64BitMode=x64
+; "ArchitecturesAllowed=x64compatible" allows Setup to run on x64 (and, under
+; emulation, ARM64) machines and install in native 64-bit mode.
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+#endif
+
+#if MyAppArch=="arm64"
+; ARM64 build: only run and install natively on ARM64 Windows.
+ArchitecturesAllowed=arm64
+ArchitecturesInstallIn64BitMode=arm64
 #endif
 
 [Languages]

--- a/scripts/release_AppImage.sh
+++ b/scripts/release_AppImage.sh
@@ -22,18 +22,22 @@ set -e
 
 # armv7l build on raspbian stretch
 
-# Qt path and flags set in env e.g.:
-# export PATH="/opt/Qt/5.14.0/bin/:$PATH"
-# export CPPFLAGS="-I/opt/Qt/5.14.0/bin/include/"
-# export LDFLAGS="-L/opt/Qt/5.14.0/bin/lib/"
-# export LD_LIBRARY_PATH="/opt/Qt/5.14.0/bin/lib/:$LD_LIBRARY_PATH"
+# Qt 6 path and flags set in env e.g.:
+# export PATH="/opt/Qt/6.11.1/gcc_64/bin/:$PATH"
+# export CPPFLAGS="-I/opt/Qt/6.11.1/gcc_64/include/"
+# export LDFLAGS="-L/opt/Qt/6.11.1/gcc_64/lib/"
+# export LD_LIBRARY_PATH="/opt/Qt/6.11.1/gcc_64/lib/:$LD_LIBRARY_PATH"
+#
+# NOTE: linuxdeploy-plugin-qt must be a recent build that supports Qt 6.
+# Qt 6 requires a reasonably modern base distribution (glibc/GL); building the
+# AppImage on an older LTS than the Qt 6 minimum will not work.
 
-# for x86_64 and i686 platform
-# Qt 5.14.0 uses openssl 1.1 and some older distros still use 1.0
-# we build openssl 1.1.1g from source using following setup:
-# ./config shared --prefix=/opt/openssl-1.1.1/ && make --jobs=`nproc --all` && sudo make install
+# for x86_64 platform
+# Qt 6 links against OpenSSL 3.x; build it from source when the host distro
+# ships an older OpenSSL, e.g.:
+# ./config shared --prefix=/opt/openssl-3/ && make --jobs=`nproc --all` && sudo make install
 # and add to build env
-# export LD_LIBRARY_PATH="/opt/openssl-1.1.1/lib/:$LD_LIBRARY_PATH"
+# export LD_LIBRARY_PATH="/opt/openssl-3/lib/:$LD_LIBRARY_PATH"
 
 if [ "$1" = "SIGN" ]; then
   export SIGN="1"
@@ -132,9 +136,9 @@ cp "$ROOT"/LICENSE "$TEMP_BASE"/"$TARGET"/AppDir/License.txt
 linuxdeploy --appdir AppDir --desktop-file=AppDir/usr/share/applications/rclone-browser.desktop --plugin qt
 #linuxdeploy-plugin-qt --appdir AppDir
 
-# we add openssl 1.1.1 libs needed for distros still using openssl 1.0
-cp /opt/openssl-1.1.1/lib/libssl.so.1.1 ./AppDir/usr/bin/
-cp /opt/openssl-1.1.1/lib/libcrypto.so.1.1 ./AppDir/usr/bin/
+# bundle OpenSSL 3.x libs (Qt 6 TLS backend) for distros without OpenSSL 3
+cp /opt/openssl-3/lib/libssl.so.3 ./AppDir/usr/bin/
+cp /opt/openssl-3/lib/libcrypto.so.3 ./AppDir/usr/bin/
 
 # https://github.com/linuxdeploy/linuxdeploy-plugin-appimage
 linuxdeploy-plugin-appimage --appdir=AppDir

--- a/scripts/release_macOS.sh
+++ b/scripts/release_macOS.sh
@@ -2,7 +2,13 @@
 
 set -e
 
-QTDIR=/usr/local/opt/qt
+# Homebrew installs Qt 6 under /opt/homebrew on Apple Silicon and
+# /usr/local on Intel. Override QTDIR to point at another Qt 6 kit if needed.
+if [ -d /opt/homebrew/opt/qt ]; then
+  QTDIR=/opt/homebrew/opt/qt
+else
+  QTDIR=/usr/local/opt/qt
+fi
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"/..
 VERSION=$(cat "$ROOT"/VERSION)-$(git rev-parse --short HEAD)
@@ -29,12 +35,12 @@ fi
 
 mkdir -p "$BUILD"
 cd "$BUILD"
-# brew install cmake qt5
+# brew install cmake qt
 cmake .. -DCMAKE_PREFIX_PATH="$QTDIR" -DCMAKE_BUILD_TYPE=Release
 # brew install coreutils
 make --jobs=$(nproc --all)
 cd build
-"$QTDIR"/bin/macdeployqt rclone-browser.app -executable="rclone-browser.app/Contents/MacOS/rclone-browser" -qmldir=../src/
+"$QTDIR"/bin/macdeployqt rclone-browser.app -executable="rclone-browser.app/Contents/MacOS/rclone-browser"
 cd ../..
 
 

--- a/scripts/release_windows.cmd
+++ b/scripts/release_windows.cmd
@@ -5,33 +5,42 @@ call :setESC
 setlocal enabledelayedexpansion
 
 if "%1" == "" (
-  echo Please specify x86 ^(32-bit^) or x64 ^(64-bit^) architecture in cmdline
+  echo Please specify x64 ^(64-bit^) or arm64 architecture in cmdline
   goto :eof
 )
 
 set BOTH=0
-if not "%1" == "x86" if not "%1" == "x64" set BOTH=1
+if not "%1" == "x64" if not "%1" == "arm64" set BOTH=1
 
 if %BOTH% == 1  (
-  echo Only x86 ^(32-bit^) or x64 ^(64-bit^) architectures are supported!
+  echo Only x64 ^(64-bit^) or arm64 architectures are supported!
+  echo Qt 6 no longer ships 32-bit Windows desktop kits.
   goto :eof
 )
 
 set ARCH=%1
-call "c:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %ARCH% || ( call :setESC & echo. & echo. & echo %ESC%[91mBuild FAILED.%ESC%[0m  & EXIT /B 1)
-
-
-
-if "%ARCH%" == "x86" (
-set QT=C:\Qt\5.15.2\msvc2019\
+rem Cross-compile ARM64 from an x64 host; build x64 natively.
+if "%ARCH%" == "arm64" (
+set VCVARS_ARCH=amd64_arm64
 ) else (
-set QT=C:\Qt\5.15.2\msvc2019_64\
+set VCVARS_ARCH=x64
+)
+call "c:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat" %VCVARS_ARCH% || ( call :setESC & echo. & echo. & echo %ESC%[91mBuild FAILED.%ESC%[0m  & EXIT /B 1)
+
+
+
+if "%ARCH%" == "arm64" (
+set QT=C:\Qt\6.11.1\msvc2022_arm64\
+set CMAKE_ARCH=ARM64
+) else (
+set QT=C:\Qt\6.11.1\msvc2022_64\
+set CMAKE_ARCH=x64
 )
 set PATH=%QT%\bin;%PATH%
 
 set ROOT="%~dp0.."
 set BUILD="%~dp0..\build\build\release"
-set CMAKEGEN="Visual Studio 16 2019"
+set CMAKEGEN="Visual Studio 17 2022"
 
 set /p VERSION=<"%ROOT%\VERSION"
 
@@ -43,9 +52,9 @@ if "%ERRORLEVEL%" equ "0" (
   set VERSION_COMMIT=%VERSION%-!COMMIT!
 )
 
-if "%ARCH%" == "x86" (
-  set TARGET="%~dp0\..\release\rclone-browser-%VERSION_COMMIT%-windows-32-bit"
-  set TARGET_EXE="%~dp0\..\release\rclone-browser-%VERSION_COMMIT%-windows-32-bit"
+if "%ARCH%" == "arm64" (
+  set TARGET="%~dp0\..\release\rclone-browser-%VERSION_COMMIT%-windows-arm64"
+  set TARGET_EXE="%~dp0\..\release\rclone-browser-%VERSION_COMMIT%-windows-arm64"
 ) else (
   set TARGET="%~dp0\..\release\rclone-browser-%VERSION_COMMIT%-windows-64-bit"
   set TARGET_EXE="%~dp0\..\release\rclone-browser-%VERSION_COMMIT%-windows-64-bit"
@@ -63,11 +72,7 @@ if exist build rd /s /q build || ( call :setESC & echo. & echo. & echo %ESC%[91m
 mkdir build || ( call :setESC & echo. & echo. & echo %ESC%[91mBuild FAILED.%ESC%[0m  & EXIT /B 1)
 cd build || ( call :setESC & echo. & echo. & echo %ESC%[91mBuild FAILED.%ESC%[0m  & EXIT /B 1)
 
-if "%ARCH%" == "x86" (
-cmake -G %CMAKEGEN% -A Win32 -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_PREFIX_PATH=%QT% .. || ( call :setESC & echo. & echo. & echo %ESC%[91mBuild FAILED.%ESC%[0m  & EXIT /B 1)
-) else (
-cmake -G %CMAKEGEN% -A x64 -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_PREFIX_PATH=%QT% .. || ( call :setESC & echo. & echo. & echo %ESC%[91mBuild FAILED.%ESC%[0m  & EXIT /B 1)
-)
+cmake -G %CMAKEGEN% -A %CMAKE_ARCH% -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_PREFIX_PATH=%QT% .. || ( call :setESC & echo. & echo. & echo %ESC%[91mBuild FAILED.%ESC%[0m  & EXIT /B 1)
 
 cmake --build . --config Release || ( call :setESC & echo. & echo. & echo %ESC%[91mBuild FAILED.%ESC%[0m  & EXIT /B 1)
 popd
@@ -79,20 +84,21 @@ copy "%ROOT%\CHANGELOG.md" "%TARGET%\Changelog.md" || ( call :setESC & echo. & e
 copy "%ROOT%\LICENSE" "%TARGET%\License.txt" || ( call :setESC & echo. & echo. & echo %ESC%[91mBuild FAILED.%ESC%[0m  & EXIT /B 1)
 copy "%BUILD%\RcloneBrowser.exe" "%TARGET%" || ( call :setESC & echo. & echo. & echo %ESC%[91mBuild FAILED.%ESC%[0m  & EXIT /B 1)
 
-windeployqt.exe --no-translations --no-angle --no-compiler-runtime "%TARGET%\RcloneBrowser.exe" || ( call :setESC & echo. & echo. & echo %ESC%[91mBuild FAILED.%ESC%[0m  & EXIT /B 1)
+windeployqt.exe --no-translations --no-compiler-runtime "%TARGET%\RcloneBrowser.exe" || ( call :setESC & echo. & echo. & echo %ESC%[91mBuild FAILED.%ESC%[0m  & EXIT /B 1)
 rd /s /q "%TARGET%\imageformats" || ( call :setESC & echo. & echo. & echo %ESC%[91mBuild FAILED.%ESC%[0m  & EXIT /B 1)
 
-rem include all MSVCruntime dlls
-copy "%VCToolsRedistDir%\%ARCH%\Microsoft.VC142.CRT\msvcp140.dll" "%TARGET%\" || ( call :setESC & echo. & echo. & echo %ESC%[91mBuild FAILED.%ESC%[0m  & EXIT /B 1)
-copy "%VCToolsRedistDir%\%ARCH%\Microsoft.VC142.CRT\vcruntime140*.dll" "%TARGET%\" || ( call :setESC & echo. & echo. & echo %ESC%[91mBuild FAILED.%ESC%[0m  & EXIT /B 1)
+rem include all MSVCruntime dlls (VS 2022 uses the VC143 runtime)
+copy "%VCToolsRedistDir%\%ARCH%\Microsoft.VC143.CRT\msvcp140.dll" "%TARGET%\" || ( call :setESC & echo. & echo. & echo %ESC%[91mBuild FAILED.%ESC%[0m  & EXIT /B 1)
+copy "%VCToolsRedistDir%\%ARCH%\Microsoft.VC143.CRT\vcruntime140*.dll" "%TARGET%\" || ( call :setESC & echo. & echo. & echo %ESC%[91mBuild FAILED.%ESC%[0m  & EXIT /B 1)
 
-rem include relevant openssl libraries
-if "%ARCH%" == "x86" (
-copy "c:\Program Files (x86)\openssl-1.1.1-win32\libssl-1_1.dll" "%TARGET%\" || ( call :setESC & echo. & echo. & echo %ESC%[91mBuild FAILED.%ESC%[0m  & EXIT /B 1)
-copy "c:\Program Files (x86)\openssl-1.1.1-win32\libcrypto-1_1.dll" "%TARGET%\" || ( call :setESC & echo. & echo. & echo %ESC%[91mBuild FAILED.%ESC%[0m  & EXIT /B 1)
+rem include relevant OpenSSL 3.x libraries (Qt 6 links against OpenSSL 3)
+rem Adjust these paths to your installed OpenSSL 3.x location.
+if "%ARCH%" == "arm64" (
+copy "c:\Program Files\openssl-3-arm64\libssl-3-arm64.dll" "%TARGET%\" || ( call :setESC & echo. & echo. & echo %ESC%[91mBuild FAILED.%ESC%[0m  & EXIT /B 1)
+copy "c:\Program Files\openssl-3-arm64\libcrypto-3-arm64.dll" "%TARGET%\" || ( call :setESC & echo. & echo. & echo %ESC%[91mBuild FAILED.%ESC%[0m  & EXIT /B 1)
 ) else (
-copy "c:\Program Files\openssl-1.1.1-win64\libssl-1_1-x64.dll" "%TARGET%\" || ( call :setESC & echo. & echo. & echo %ESC%[91mBuild FAILED.%ESC%[0m  & EXIT /B 1)
-copy "c:\Program Files\openssl-1.1.1-win64\libcrypto-1_1-x64.dll" "%TARGET%\" || ( call :setESC & echo. & echo. & echo %ESC%[91mBuild FAILED.%ESC%[0m  & EXIT /B 1)
+copy "c:\Program Files\openssl-3-win64\libssl-3-x64.dll" "%TARGET%\" || ( call :setESC & echo. & echo. & echo %ESC%[91mBuild FAILED.%ESC%[0m  & EXIT /B 1)
+copy "c:\Program Files\openssl-3-win64\libcrypto-3-x64.dll" "%TARGET%\" || ( call :setESC & echo. & echo. & echo %ESC%[91mBuild FAILED.%ESC%[0m  & EXIT /B 1)
 )
 
 (
@@ -111,16 +117,16 @@ rem Inno Setup installer by https://github.com/jrsoftware/issrc
 rem in case user wants to install both 32bits and 64bits versions we need two AppId
 rem 64bits ;AppId={{0AF9BF43-8D44-4AFF-AE60-6CECF1BF0D31}
 rem 32bits ;AppId={{5644ED3A-6028-47C0-9796-29548EF7CEA3}
-if "%ARCH%" == "x86" (
-"c:\Program Files (x86)\Inno Setup 6"\iscc "/dMyAppVersion=%VERSION%" "/dMyAppId={{5644ED3A-6028-47C0-9796-29548EF7CEA3}" "/dMyAppDir=rclone-browser-%VERSION_COMMIT%-windows-32-bit" "/dMyAppArch=x86" /O"../release" /F"rclone-browser-%VERSION_COMMIT%-windows-32-bit" rclone-browser-win-installer.iss || ( call :setESC & echo. & echo. & echo %ESC%[91mBuild FAILED.%ESC%[0m  & EXIT /B 1)
+if "%ARCH%" == "arm64" (
+"c:\Program Files (x86)\Inno Setup 6"\iscc "/dMyAppVersion=%VERSION%" "/dMyAppId={{5644ED3A-6028-47C0-9796-29548EF7CEA3}" "/dMyAppDir=rclone-browser-%VERSION_COMMIT%-windows-arm64" "/dMyAppArch=arm64" /O"../release" /F"rclone-browser-%VERSION_COMMIT%-windows-arm64" rclone-browser-win-installer.iss || ( call :setESC & echo. & echo. & echo %ESC%[91mBuild FAILED.%ESC%[0m  & EXIT /B 1)
 ) else (
 "c:\Program Files (x86)\Inno Setup 6"\iscc "/dMyAppVersion=%VERSION%" "/dMyAppId={{0AF9BF43-8D44-4AFF-AE60-6CECF1BF0D31}" "/dMyAppDir=rclone-browser-%VERSION_COMMIT%-windows-64-bit" "/dMyAppArch=x64" /O"../release" /F"rclone-browser-%VERSION_COMMIT%-windows-64-bit" rclone-browser-win-installer.iss || ( call :setESC & echo. & echo. & echo %ESC%[91mBuild FAILED.%ESC%[0m  & EXIT /B 1)
 )
 
 rem Build OK
 
-if "%ARCH%" == "x86" (
-call :setESC & echo. & echo. & echo %ESC%[92mWindows 32-bit build OK.%ESC%[0m & exit /B 0
+if "%ARCH%" == "arm64" (
+call :setESC & echo. & echo. & echo %ESC%[92mWindows ARM64 build OK.%ESC%[0m & exit /B 0
 )
 
 if "%ARCH%" == "x64" (

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,23 +5,25 @@ endif()
 if(WIN32)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /WX /wd4100 /wd4189")
 else()
-  add_definitions("-pedantic -Wall -Wextra -Werror -std=c++11")
+  add_definitions("-pedantic -Wall -Wextra -Werror")
 endif()
 
 if (APPLE)
-  set(CMAKE_OSX_DEPLOYMENT_TARGET 10.13)
+  set(CMAKE_OSX_DEPLOYMENT_TARGET 12.0)
 endif()
 
-FIND_PACKAGE(Qt5Core REQUIRED)
-FIND_PACKAGE(Qt5Gui REQUIRED)
-FIND_PACKAGE(Qt5Widgets REQUIRED)
-FIND_PACKAGE(Qt5Network REQUIRED)
-FIND_PACKAGE(Qt5Multimedia REQUIRED)
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets Network)
+find_package(Qt6 QUIET OPTIONAL_COMPONENTS Multimedia)
 
-if (WIN32)
-FIND_PACKAGE(Qt5WinExtras REQUIRED)
-elseif(APPLE)
-FIND_PACKAGE(Qt5MacExtras REQUIRED)
+# Qt 6 makes the QFileInfo(const QString &) constructor explicit by default.
+# Keep the Qt 5 implicit behaviour to avoid churn across the codebase.
+add_definitions(-DQT_IMPLICIT_QFILEINFO_CONSTRUCTION)
+
+# Enable the notification sound only when the Multimedia module is available.
+set(OPTIONAL_QT_LIBS "")
+if(TARGET Qt6::Multimedia)
+  add_definitions(-DRB_HAVE_MULTIMEDIA)
+  list(APPEND OPTIONAL_QT_LIBS Qt6::Multimedia)
 endif()
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -126,9 +128,9 @@ set(QRC resources.qrc)
 
 add_definitions(-DRCLONE_BROWSER_VERSION="${RCLONE_BROWSER_VERSION}")
 
-qt5_wrap_ui(UI_OUT ${UI})
-qt5_wrap_cpp(MOC_OUT ${MOC})
-qt5_add_resources(QRC_OUT ${QRC} OPTIONS "-no-compress")
+qt6_wrap_ui(UI_OUT ${UI})
+qt6_wrap_cpp(MOC_OUT ${MOC})
+qt6_add_resources(QRC_OUT ${QRC} OPTIONS "-no-compress")
 
 source_group("" FILES ${SOURCE} ${MOC} ${UI} ${QRC} ${OTHER})
 source_group("Generated" FILES ${MOC_OUT} ${UI_OUT} ${MOC_OUT} ${QRC_OUT})
@@ -155,16 +157,16 @@ ADD_MSVC_PRECOMPILED_HEADER(pch.h pch.cpp MOC_OUT)
 
 if(WIN32)
   add_executable(RcloneBrowser WIN32 ${SOURCE} ${BACKEND} ${OTHER} ${MOC} ${MOC_OUT} ${UI_OUT} ${MOC_OUT} ${QRC_OUT})
-  target_link_libraries(RcloneBrowser Qt5::Widgets Qt5::Network Qt5::WinExtras Qt5::Multimedia)
+  target_link_libraries(RcloneBrowser Qt6::Widgets Qt6::Network ${OPTIONAL_QT_LIBS})
 elseif(APPLE)
   set_source_files_properties(icon.icns PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
   add_executable(rclone-browser MACOSX_BUNDLE ${SOURCE} ${BACKEND} ${OTHER} ${MOC} ${MOC_OUT} ${UI_OUT} ${MOC_OUT} ${QRC_OUT} icon.icns)
-  target_link_libraries(rclone-browser Qt5::Widgets Qt5::Network Qt5::MacExtras Qt5::Multimedia ${COCOA_LIB} ${IOKKIT_LIB})
+  target_link_libraries(rclone-browser Qt6::Widgets Qt6::Network ${OPTIONAL_QT_LIBS} ${COCOA_LIB} ${IOKKIT_LIB})
   set_target_properties(rclone-browser PROPERTIES MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Info.plist")
 
 else()
   add_executable(rclone-browser ${SOURCE} ${BACKEND} ${OTHER} ${MOC} ${MOC_OUT} ${UI_OUT} ${MOC_OUT} ${QRC_OUT})
-  target_link_libraries(rclone-browser Qt5::Widgets Qt5::Network Qt5::Multimedia)
+  target_link_libraries(rclone-browser Qt6::Widgets Qt6::Network ${OPTIONAL_QT_LIBS})
 
   install(TARGETS rclone-browser RUNTIME DESTINATION bin)
   install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/../assets/rclone-browser.svg" DESTINATION "share/icons/hicolor/scalable/apps" RENAME "rclone-browser.svg")

--- a/src/check_dialog.cpp
+++ b/src/check_dialog.cpp
@@ -98,7 +98,7 @@ QStringList CheckDialog::getOptions() const {
   QString extra = ui.textExtra->text().trimmed();
   if (!extra.isEmpty()) {
     for (QString arg :
-         extra.split(QRegExp(" (?=[^\"]*(\"[^\"]*\"[^\"]*)*$)"))) {
+         extra.split(QRegularExpression(" (?=[^\"]*(\"[^\"]*\"[^\"]*)*$)"))) {
       if (!arg.isEmpty()) {
         list << arg.replace("\"", "");
       }

--- a/src/dedupe_dialog.cpp
+++ b/src/dedupe_dialog.cpp
@@ -83,7 +83,7 @@ QStringList DedupeDialog::getOptions() const {
   QString extra = ui.textExtra->text().trimmed();
   if (!extra.isEmpty()) {
     for (QString arg :
-         extra.split(QRegExp(" (?=[^\"]*(\"[^\"]*\"[^\"]*)*$)"))) {
+         extra.split(QRegularExpression(" (?=[^\"]*(\"[^\"]*\"[^\"]*)*$)"))) {
       if (!arg.isEmpty()) {
         list << arg.replace("\"", "");
       }

--- a/src/icon_cache.cpp
+++ b/src/icon_cache.cpp
@@ -35,7 +35,7 @@ void IconCache::getIcon(Item *item, const QPersistentModelIndex &parent) {
                        FILE_ATTRIBUTE_NORMAL, &info, sizeof(info),
                        SHGFI_ICON | SHGFI_USEFILEATTRIBUTES) &&
         info.hIcon) {
-      icon = QtWin::fromHICON(info.hIcon);
+      icon = QIcon(QPixmap::fromImage(QImage::fromHICON(info.hIcon)));
       DestroyIcon(info.hIcon);
     }
 #elif defined(Q_OS_MACOS)

--- a/src/item_model.cpp
+++ b/src/item_model.cpp
@@ -82,10 +82,10 @@ private:
 ItemModel::ItemModel(IconCache *icons, const QString &remote, QObject *parent)
     : QAbstractItemModel(parent), mRemote(remote),
       mFixedFont(QFontDatabase::systemFont(QFontDatabase::FixedFont)),
-      mRegExpFolder(
-          R"(^\s*[\d-]+ (\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d) \s*[\d-]+ (.+)$)"),
-      mRegExpFile(
-          R"(^\s*(\d+) (\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d)\.\d+ (.+)$)") {
+      mRegExpFolder(QRegularExpression::anchoredPattern(
+          R"(\s*[\d-]+ (\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d) \s*[\d-]+ (.+))")),
+      mRegExpFile(QRegularExpression::anchoredPattern(
+          R"(\s*(\d+) (\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d)\.\d+ (.+))")) {
   QStyle *style = qApp->style();
   mDriveIcon = style->standardIcon(QStyle::SP_DriveNetIcon);
   mFolderIcon = style->standardIcon(QStyle::SP_DirIcon);
@@ -272,7 +272,7 @@ QVariant ItemModel::data(const QModelIndex &index, int role) const {
 
   if (role == Qt::TextAlignmentRole) {
     if (index.column() == 1) {
-      return Qt::AlignRight + Qt::AlignVCenter;
+      return QVariant::fromValue(Qt::AlignRight | Qt::AlignVCenter);
     }
     return QVariant();
   }
@@ -517,8 +517,9 @@ void ItemModel::load(const QPersistentModelIndex &parentIndex, Item *parent) {
       QString line = lsd->readLine();
       line.replace("\n", "");
 
-      if (mRegExpFolder.exactMatch(line)) {
-        QStringList cap = mRegExpFolder.capturedTexts();
+      QRegularExpressionMatch match = mRegExpFolder.match(line);
+      if (match.hasMatch()) {
+        QStringList cap = match.capturedTexts();
 
         Item *child = new Item();
         child->isFolder = true;
@@ -537,8 +538,9 @@ void ItemModel::load(const QPersistentModelIndex &parentIndex, Item *parent) {
       QString line = lsl->readLine();
       line.replace("\n", "");
 
-      if (mRegExpFile.exactMatch(line)) {
-        QStringList cap = mRegExpFile.capturedTexts();
+      QRegularExpressionMatch match = mRegExpFile.match(line);
+      if (match.hasMatch()) {
+        QStringList cap = match.capturedTexts();
 
         Item *child = new Item();
         child->parent = parent;

--- a/src/item_model.h
+++ b/src/item_model.h
@@ -98,8 +98,8 @@ private:
   int mSortColumn;
   Qt::SortOrder mSortOrder;
 
-  QRegExp mRegExpFolder;
-  QRegExp mRegExpFile;
+  QRegularExpression mRegExpFolder;
+  QRegularExpression mRegExpFile;
 
   QMutex mRcloneLsProcessCountMutex;
 

--- a/src/job_options.cpp
+++ b/src/job_options.cpp
@@ -163,7 +163,7 @@ QStringList JobOptions::getOptions() const {
       // --option-2="arg1 arg2" --option-3 arg3 should generate "--option-1"
       // "--option-2=\"arg1 arg2\"" "--option-3" "arg3"
       for (QString arg :
-           line.split(QRegExp(" (?=[^\"]*(\"[^\"]*\"[^\"]*)*$)"))) {
+           line.split(QRegularExpression(" (?=[^\"]*(\"[^\"]*\"[^\"]*)*$)"))) {
         if (!arg.isEmpty()) {
           list << arg.replace("\"", "");
         }

--- a/src/job_widget.cpp
+++ b/src/job_widget.cpp
@@ -133,30 +133,33 @@ JobWidget::JobWidget(QProcess *process, const QString &info,
 
   QObject::connect(mProcess, &QProcess::readyRead, this, [=]() {
     // regex101.com great for testing regexp
-    QRegExp rxSize(
-        R"(^Transferred:\s+(\S+ \S+) \(([^)]+)\)$)"); // Until rclone 1.42
-    QRegExp rxSize2(
-        R"(^Transferred:\s+([0-9.]+)(\S)? \/ (\S+) (\S+), ([0-9%-]+), (\S+ \S+), (\S+) (\S+)$)"); // Starting with rclone 1.43
-    QRegExp rxSize3(
-        R"(^Transferred:\s+([0-9.]+ \w+) \/ ([0-9.]+ \w+), ([0-9%-]+), ([0-9.]+ \w+\/s), \w+ (\S+)$)"); // Starting with rclone 1.57
-    QRegExp rxErrors(
-        R"(^Errors:\s+(\d+)(.*)$)"); // captures also following variant:
-                                     // "Errors: 123 (bla bla bla)"
-    QRegExp rxChecks(R"(^Checks:\s+(\S+)$)"); // Until rclone 1.42
-    QRegExp rxChecks2(
-        R"(^Checks:\s+(\S+) \/ (\S+), ([0-9%-]+)$)");   // Starting with
-                                                        // rclone 1.43
-    QRegExp rxTransferred(R"(^Transferred:\s+(\S+)$)"); // Until rclone 1.42
-    QRegExp rxTransferred2(
-        R"(^Transferred:\s+(\d+) \/ (\d+), ([0-9%-]+)$)"); // Starting with
-                                                           // rclone 1.43
-    QRegExp rxTime(R"(^Elapsed time:\s+(\S+)$)");
-    QRegExp rxProgress(
-        R"(^\*([^:]+):\s*([^%]+)% done.+(ETA: [^)]+)$)"); // Until rclone 1.38
-    QRegExp rxProgress2(
-        R"(\*([^:]+):\s*([^%]+)% \/[a-zA-z0-9.]+, [a-zA-z0-9.]+\/s, (\w+)$)"); // Starting with rclone 1.39
-    QRegExp rxProgress3(
-        R"(^\* ([^:]+):\s*([^%]+%) \/([0-9.]+\w+), ([0-9.]*[a-zA-Z\/]+s)*,)"); // Starting with rclone 1.56
+    QRegularExpression rxSize(QRegularExpression::anchoredPattern(
+        R"(Transferred:\s+(\S+ \S+) \(([^)]+)\))")); // Until rclone 1.42
+    QRegularExpression rxSize2(QRegularExpression::anchoredPattern(
+        R"(Transferred:\s+([0-9.]+)(\S)? \/ (\S+) (\S+), ([0-9%-]+), (\S+ \S+), (\S+) (\S+))")); // Starting with rclone 1.43
+    QRegularExpression rxSize3(QRegularExpression::anchoredPattern(
+        R"(Transferred:\s+([0-9.]+ \w+) \/ ([0-9.]+ \w+), ([0-9%-]+), ([0-9.]+ \w+\/s), \w+ (\S+))")); // Starting with rclone 1.57
+    QRegularExpression rxErrors(QRegularExpression::anchoredPattern(
+        R"(Errors:\s+(\d+)(.*))")); // captures also following variant:
+                                    // "Errors: 123 (bla bla bla)"
+    QRegularExpression rxChecks(QRegularExpression::anchoredPattern(
+        R"(Checks:\s+(\S+))")); // Until rclone 1.42
+    QRegularExpression rxChecks2(QRegularExpression::anchoredPattern(
+        R"(Checks:\s+(\S+) \/ (\S+), ([0-9%-]+))"));   // Starting with
+                                                       // rclone 1.43
+    QRegularExpression rxTransferred(QRegularExpression::anchoredPattern(
+        R"(Transferred:\s+(\S+))")); // Until rclone 1.42
+    QRegularExpression rxTransferred2(QRegularExpression::anchoredPattern(
+        R"(Transferred:\s+(\d+) \/ (\d+), ([0-9%-]+))")); // Starting with
+                                                          // rclone 1.43
+    QRegularExpression rxTime(
+        QRegularExpression::anchoredPattern(R"(Elapsed time:\s+(\S+))"));
+    QRegularExpression rxProgress(QRegularExpression::anchoredPattern(
+        R"(\*([^:]+):\s*([^%]+)% done.+(ETA: [^)]+))")); // Until rclone 1.38
+    QRegularExpression rxProgress2(QRegularExpression::anchoredPattern(
+        R"(\*([^:]+):\s*([^%]+)% \/[a-zA-z0-9.]+, [a-zA-z0-9.]+\/s, (\w+))")); // Starting with rclone 1.39
+    QRegularExpression rxProgress3(QRegularExpression::anchoredPattern(
+        R"(\* ([^:]+):\s*([^%]+%) \/([0-9.]+\w+), ([0-9.]*[a-zA-Z\/]+s)*,)")); // Starting with rclone 1.56
     while (mProcess->canReadLine()) {
       QString line = mProcess->readLine().trimmed();
       if (++mLines == 10000) {
@@ -183,61 +186,54 @@ JobWidget::JobWidget(QProcess *process, const QString &info,
         continue;
       }
 
-      if (rxSize.exactMatch(line)) {
-        ui.size->setText(rxSize.cap(1));
+      QRegularExpressionMatch m;
+      if ((m = rxSize.match(line)).hasMatch()) {
+        ui.size->setText(m.captured(1));
 
         ui.progress_info->setStyleSheet(
             "QLabel { color: green; font-weight: bold;}");
-        ui.progress_info->setText("(" + rxSize.cap(1) + ")");
+        ui.progress_info->setText("(" + m.captured(1) + ")");
 
-        ui.bandwidth->setText(rxSize.cap(2));
-      } else if (rxSize2.exactMatch(line)) {
-        ui.size->setText(rxSize2.cap(1) + " " + rxSize2.cap(2) + "B" + ", " +
-                         rxSize2.cap(5));
-        ui.bandwidth->setText(rxSize2.cap(6));
-        ui.eta->setText(rxSize2.cap(8));
-        ui.totalsize->setText(rxSize2.cap(3) + " " + rxSize2.cap(4));
-        
+        ui.bandwidth->setText(m.captured(2));
+      } else if ((m = rxSize2.match(line)).hasMatch()) {
+        ui.size->setText(m.captured(1) + " " + m.captured(2) + "B" + ", " +
+                         m.captured(5));
+        ui.bandwidth->setText(m.captured(6));
+        ui.eta->setText(m.captured(8));
+        ui.totalsize->setText(m.captured(3) + " " + m.captured(4));
+
         ui.progress_info->setStyleSheet(
             "QLabel { color: green; font-weight: bold;}");
-        ui.progress_info->setText("(" + rxSize2.cap(5) + ")");
+        ui.progress_info->setText("(" + m.captured(5) + ")");
 
+      } else if ((m = rxSize3.match(line)).hasMatch()) {
+        ui.size->setText(m.captured(1) + ", " + m.captured(3));
+        ui.bandwidth->setText(m.captured(4));
+        ui.eta->setText(m.captured(5));
+        ui.totalsize->setText(m.captured(2));
+      } else if ((m = rxErrors.match(line)).hasMatch()) {
+        ui.errors->setText(m.captured(1));
 
-
-
-
-
-
-
-      } else if (rxSize3.exactMatch(line)) {
-        ui.size->setText(rxSize3.cap(1) + ", " + rxSize3.cap(3));
-        ui.bandwidth->setText(rxSize3.cap(4));
-        ui.eta->setText(rxSize3.cap(5));
-        ui.totalsize->setText(rxSize3.cap(2));
-      } else if (rxErrors.exactMatch(line)) {
-        ui.errors->setText(rxErrors.cap(1));
-
-        if (!(rxErrors.cap(1).toInt() == 0)) {
+        if (!(m.captured(1).toInt() == 0)) {
           ui.progress_info->setStyleSheet(
               "QLabel { color: red; font-weight: bold;}");
           ui.errors->setStyleSheet(
               "QLineEdit { color: red; font-weight: normal;}");
         }
-      } else if (rxChecks.exactMatch(line)) {
-        ui.checks->setText(rxChecks.cap(1));
-      } else if (rxChecks2.exactMatch(line)) {
-        ui.checks->setText(rxChecks2.cap(1) + " / " + rxChecks2.cap(2) + ", " +
-                           rxChecks2.cap(3));
-      } else if (rxTransferred.exactMatch(line)) {
-        ui.transferred->setText(rxTransferred.cap(1));
-      } else if (rxTransferred2.exactMatch(line)) {
-        ui.transferred->setText(rxTransferred2.cap(1) + " / " +
-                                rxTransferred2.cap(2) + ", " +
-                                rxTransferred2.cap(3));
-      } else if (rxTime.exactMatch(line)) {
-        ui.elapsed->setText(rxTime.cap(1));
-      } else if (rxProgress.exactMatch(line)) {
-        QString name = rxProgress.cap(1).trimmed();
+      } else if ((m = rxChecks.match(line)).hasMatch()) {
+        ui.checks->setText(m.captured(1));
+      } else if ((m = rxChecks2.match(line)).hasMatch()) {
+        ui.checks->setText(m.captured(1) + " / " + m.captured(2) + ", " +
+                           m.captured(3));
+      } else if ((m = rxTransferred.match(line)).hasMatch()) {
+        ui.transferred->setText(m.captured(1));
+      } else if ((m = rxTransferred2.match(line)).hasMatch()) {
+        ui.transferred->setText(m.captured(1) + " / " + m.captured(2) + ", " +
+                                m.captured(3));
+      } else if ((m = rxTime.match(line)).hasMatch()) {
+        ui.elapsed->setText(m.captured(1));
+      } else if ((m = rxProgress.match(line)).hasMatch()) {
+        QString name = m.captured(1).trimmed();
 
         auto it = mActive.find(name);
 
@@ -262,12 +258,12 @@ JobWidget::JobWidget(QProcess *process, const QString &info,
           bar = static_cast<QProgressBar *>(label->buddy());
         }
 
-        bar->setValue(rxProgress.cap(2).toInt());
-        bar->setToolTip(rxProgress.cap(3));
+        bar->setValue(m.captured(2).toInt());
+        bar->setToolTip(m.captured(3));
 
         mUpdated.insert(label);
-      } else if (rxProgress2.exactMatch(line)) {
-        QString name = rxProgress2.cap(1).trimmed();
+      } else if ((m = rxProgress2.match(line)).hasMatch()) {
+        QString name = m.captured(1).trimmed();
 
         auto it = mActive.find(name);
 
@@ -301,14 +297,13 @@ JobWidget::JobWidget(QProcess *process, const QString &info,
           bar = static_cast<QProgressBar *>(label->buddy());
         }
 
-        bar->setValue(rxProgress2.cap(2).toInt());
-        bar->setToolTip(
-            "File name: " + name + "\nFile stats" +
-            rxProgress2.cap(0).mid(rxProgress2.cap(0).indexOf(':')));
+        bar->setValue(m.captured(2).toInt());
+        bar->setToolTip("File name: " + name + "\nFile stats" +
+                        m.captured(0).mid(m.captured(0).indexOf(':')));
 
         mUpdated.insert(label);
-      } else if (rxProgress3.exactMatch(line)) {
-        QString name = rxProgress3.cap(1).trimmed();
+      } else if ((m = rxProgress3.match(line)).hasMatch()) {
+        QString name = m.captured(1).trimmed();
 
         auto it = mActive.find(name);
 
@@ -342,8 +337,9 @@ JobWidget::JobWidget(QProcess *process, const QString &info,
           bar = static_cast<QProgressBar *>(label->buddy());
         }
 
-        bar->setValue(rxProgress3.cap(2).toInt());
-        bar->setToolTip("File name: " + name + "\nFile stats" + rxProgress3.cap(0).mid(rxProgress3.cap(0).indexOf(':')));
+        bar->setValue(m.captured(2).toInt());
+        bar->setToolTip("File name: " + name + "\nFile stats" +
+                        m.captured(0).mid(m.captured(0).indexOf(':')));
 
         mUpdated.insert(label);
       }

--- a/src/list_of_job_options.cpp
+++ b/src/list_of_job_options.cpp
@@ -78,8 +78,8 @@ QString ListOfJobOptions::GetPersistenceFilePath() {
   } else {
 
     // get data location folder from Qt  - OS dependend
-    outputDir =
-        QDir(QStandardPaths::writableLocation(QStandardPaths::DataLocation));
+    outputDir = QDir(
+        QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation));
   }
 
   // make sure the destination folder exists, otherwise saving would fail

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,7 +62,10 @@ int main(int argc, char *argv[]) {
   qt_set_sequence_auto_mnemonic(true);
 #endif
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+// Qt 6 always enables high-DPI scaling, so these attributes are only needed
+// (and only exist) on Qt 5.
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0) &&                                  \
+    QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
   static const char ENV_VAR_QT_DEVICE_PIXEL_RATIO[] = "QT_DEVICE_PIXEL_RATIO";
   if (!qEnvironmentVariableIsSet(ENV_VAR_QT_DEVICE_PIXEL_RATIO) &&
       !qEnvironmentVariableIsSet("QT_AUTO_SCREEN_SCALE_FACTOR") &&

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -35,8 +35,8 @@ MainWindow::MainWindow() {
 
   auto settings = GetSettings();
 
-#if defined(Q_OS_WIN)
-  // disable "?" WindowContextHelpButton
+#if defined(Q_OS_WIN) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+  // disable "?" WindowContextHelpButton (Qt 6 no longer shows it by default)
   QApplication::setAttribute(Qt::AA_DisableWindowContextHelpButton);
 #endif
 
@@ -3939,7 +3939,7 @@ void MainWindow::runItem(JobOptionsListWidgetItem *item,
       for (auto line : jo->extra.trimmed().split('\n')) {
         if (!line.isEmpty()) {
           for (QString arg :
-               line.split(QRegExp(" (?=[^\"]*(\"[^\"]*\"[^\"]*)*$)"))) {
+               line.split(QRegularExpression(" (?=[^\"]*(\"[^\"]*\"[^\"]*)*$)"))) {
             if (!arg.isEmpty()) {
               args << arg.replace("\"", "");
             }
@@ -4257,7 +4257,13 @@ void MainWindow::addTransfer(const QString &message, const QString &source,
 
         if (mSoundNotif) {
           // play notification sound
-          QSound::play(":media/sounds/notification-sound.wav");
+#ifdef RB_HAVE_MULTIMEDIA
+          if (mNotificationSound.source().isEmpty()) {
+            mNotificationSound.setSource(
+                QUrl("qrc:/media/sounds/notification-sound.wav"));
+          }
+          mNotificationSound.play();
+#endif
         }
 
         --mTransferJobCount;
@@ -4582,7 +4588,7 @@ void MainWindow::runScript(const QString &script) {
 
   QStringList scriptList;
 
-  for (QString arg : script.split(QRegExp(" (?=[^\"]*(\"[^\"]*\"[^\"]*)*$)"))) {
+  for (QString arg : script.split(QRegularExpression(" (?=[^\"]*(\"[^\"]*\"[^\"]*)*$)"))) {
     if (!arg.isEmpty()) {
       scriptList << arg.replace("\"", "");
     }
@@ -4621,7 +4627,7 @@ void MainWindow::addNewMount(const QString &remote, const QString &folder,
     // split on spaces but not if inside quotes e.g. --option-1 --option-2="arg1
     // arg2" --option-3 arg3 should generate "--option-1" "--option-2=\"arg1
     // arg2\"" "--option-3" "arg3"
-    for (QString arg : opt.split(QRegExp(" (?=[^\"]*(\"[^\"]*\"[^\"]*)*$)"))) {
+    for (QString arg : opt.split(QRegularExpression(" (?=[^\"]*(\"[^\"]*\"[^\"]*)*$)"))) {
       if (!arg.isEmpty()) {
         argsFinal << arg.replace("\"", "");
       }
@@ -5088,7 +5094,7 @@ void MainWindow::addStream(const QString &remote, const QString &stream,
 
   QStringList streamPrefsList;
 
-  for (QString arg : stream.split(QRegExp(" (?=[^\"]*(\"[^\"]*\"[^\"]*)*$)"))) {
+  for (QString arg : stream.split(QRegularExpression(" (?=[^\"]*(\"[^\"]*\"[^\"]*)*$)"))) {
     if (!arg.isEmpty()) {
       streamPrefsList << arg.replace("\"", "");
     }

--- a/src/main_window.h
+++ b/src/main_window.h
@@ -55,6 +55,11 @@ private:
   Ui::MainWindow ui;
 
   QSystemTrayIcon mSystemTray;
+  // Qt 6 removed QSound; QSoundEffect replaces it for the finished-transfer
+  // notification chime (only when the Multimedia module is available).
+#ifdef RB_HAVE_MULTIMEDIA
+  QSoundEffect mNotificationSound;
+#endif
   JobWidget *mLastFinished = nullptr;
 
   bool mAlwaysShowInTray;

--- a/src/mount_dialog.cpp
+++ b/src/mount_dialog.cpp
@@ -526,7 +526,7 @@ QStringList MountDialog::getOptions() {
       if (!line.isEmpty()) {
 
         for (QString arg :
-             line.split(QRegExp(" (?=[^\"]*(\"[^\"]*\"[^\"]*)*$)"))) {
+             line.split(QRegularExpression(" (?=[^\"]*(\"[^\"]*\"[^\"]*)*$)"))) {
           if (!arg.isEmpty()) {
             list << arg.replace("\"", "");
           }

--- a/src/mount_widget.cpp
+++ b/src/mount_widget.cpp
@@ -233,13 +233,14 @@ MountWidget::MountWidget(QProcess *process, const QString &remote,
 
   QObject::connect(mProcess, &QProcess::readyRead, this, [=]() {
     QString line;
-    QRegExp rx("^.+Serving\\sremote\\scontrol\\son\\s\\S+$");
+    QRegularExpression rx(QRegularExpression::anchoredPattern(
+        "^.+Serving\\sremote\\scontrol\\son\\s\\S+$"));
 
     while (mProcess->canReadLine()) {
       line = mProcess->readLine().trimmed();
       ui.output->appendPlainText(line);
       // we capture RC port here from rclone output
-      if (rx.exactMatch(line)) {
+      if (rx.match(line).hasMatch()) {
         line.replace("/", "");
         mRcPort = line.right(line.length() - line.lastIndexOf(":") - 1);
       }
@@ -257,11 +258,11 @@ MountWidget::MountWidget(QProcess *process, const QString &remote,
         QString password;
         int index;
 
-        index = mArgs.indexOf(QRegExp("^--rc-user\\S+"));
+        index = mArgs.indexOf(QRegularExpression("^--rc-user\\S+"));
         user = mArgs.at(index);
         user.replace("--rc-user=", "");
 
-        index = mArgs.indexOf(QRegExp("^--rc-pass\\S+"));
+        index = mArgs.indexOf(QRegularExpression("^--rc-pass\\S+"));
         password = mArgs.at(index);
         password.replace("--rc-pass=", "");
 
@@ -350,7 +351,7 @@ void MountWidget::cancel() {
       this, [=](int status, QProcess::ExitStatus) {
         if (status != 0) {
           // unmounting failed
-          mUnmountingError = status;
+          mUnmountingError = QString::number(status);
           ui.cancel->setEnabled(true);
           ui.showDetails->setStyleSheet(
               "QToolButton { border: 0; color: red; font-weight: bold;}");
@@ -385,10 +386,10 @@ void MountWidget::cancel() {
 
   unmountArgs << "localhost:" + mRcPort;
 
-  index = mArgs.indexOf(QRegExp("^--rc-user\\S+"));
+  index = mArgs.indexOf(QRegularExpression("^--rc-user\\S+"));
   user = mArgs.at(index);
 
-  index = mArgs.indexOf(QRegExp("^--rc-pass\\S+"));
+  index = mArgs.indexOf(QRegularExpression("^--rc-pass\\S+"));
   password = mArgs.at(index);
 
   unmountArgs << user << password;

--- a/src/osx_helper.mm
+++ b/src/osx_helper.mm
@@ -2,6 +2,32 @@
 #include <ApplicationServices/ApplicationServices.h>
 #include <Cocoa/Cocoa.h>
 
+// Qt 6 removed QtMacExtras (and QtMac::fromCGImageRef), so convert the
+// CGImageRef into a QImage manually by rendering it into a bitmap context.
+static QImage qt_mac_toQImage(CGImageRef image) {
+  const size_t width = CGImageGetWidth(image);
+  const size_t height = CGImageGetHeight(image);
+  if (width == 0 || height == 0) {
+    return QImage();
+  }
+
+  QImage result(static_cast<int>(width), static_cast<int>(height),
+                QImage::Format_ARGB32_Premultiplied);
+  result.fill(Qt::transparent);
+
+  CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+  CGContextRef context = CGBitmapContextCreate(
+      result.bits(), width, height, 8, result.bytesPerLine(), colorSpace,
+      kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Host);
+  if (context) {
+    CGContextDrawImage(context, CGRectMake(0, 0, width, height), image);
+    CGContextRelease(context);
+  }
+  CGColorSpaceRelease(colorSpace);
+
+  return result;
+}
+
 QIcon osxGetIcon(const QString &extension) {
   QIcon icon;
   @autoreleasepool {
@@ -12,7 +38,10 @@ QIcon osxGetIcon(const QString &extension) {
                                                 context:NULL
                                                   hints:nil];
     if (imageRef) {
-      icon = QtMac::fromCGImageRef(imageRef);
+      QImage converted = qt_mac_toQImage(imageRef);
+      if (!converted.isNull()) {
+        icon = QIcon(QPixmap::fromImage(converted));
+      }
     }
   }
   return icon;

--- a/src/pch.h
+++ b/src/pch.h
@@ -9,16 +9,23 @@
 #include <QtCore>
 #include <QtDebug>
 #include <QtGui>
-#include <QtMultimedia>
 #include <QtNetwork>
 #include <QtWidgets>
 
-#if defined(Q_OS_WIN32)
-#include <QtWinExtras>
+// QtMultimedia is optional and only pulled in when the module is available at
+// build time (see RB_HAVE_MULTIMEDIA in CMake).
+#ifdef RB_HAVE_MULTIMEDIA
+#include <QtMultimedia>
 #endif
 
-#ifdef Q_OS_MACOS
-#include <QtMacExtras>
+// Qt 6 removed QtWinExtras/QtMacExtras. On Windows the native shell APIs used
+// for file icons now come directly from the Windows SDK headers.
+#if defined(Q_OS_WIN32)
+// windows.h must precede shellapi.h (which relies on its macros/types).
+#include <windows.h>
+// clang-format off
+#include <shellapi.h>
+// clang-format on
 #endif
 
 #ifdef _MSC_VER

--- a/src/remote_folder_dialog.cpp
+++ b/src/remote_folder_dialog.cpp
@@ -340,7 +340,7 @@ QStringList RemoteFolderDialog::getOptions() {
       if (!line.isEmpty()) {
 
         for (QString arg :
-             line.split(QRegExp(" (?=[^\"]*(\"[^\"]*\"[^\"]*)*$)"))) {
+             line.split(QRegularExpression(" (?=[^\"]*(\"[^\"]*\"[^\"]*)*$)"))) {
           if (!arg.isEmpty()) {
             args << arg.replace("\"", "");
           }

--- a/src/remote_widget.cpp
+++ b/src/remote_widget.cpp
@@ -1325,7 +1325,8 @@ RemoteWidget::RemoteWidget(IconCache *iconCache, const QString &remote,
         return;
       }
 
-      QRegExp re(R"(^\s*(\d+) (\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d)\.\d+ (.+)$)");
+      QRegularExpression re(QRegularExpression::anchoredPattern(
+          R"(\s*(\d+) (\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d)\.\d+ (.+))"));
 
       QProcess *process = new QProcess;
       UseRclonePassword(process);
@@ -1353,15 +1354,16 @@ RemoteWidget::RemoteWidget(IconCache *iconCache, const QString &remote,
       QObject::connect(progress, &ProgressDialog::outputAvailable, this,
                        [=](const QString &output) {
                          QTextStream out(file);
-                         out.setCodec("UTF-8");
+                         out.setEncoding(QStringConverter::Utf8);
 
                          for (const auto &line : output.split('\n')) {
 
                            QString lineTmp = line;
                            lineTmp.replace("\n", "");
 
-                           if (re.exactMatch(lineTmp)) {
-                             QStringList cap = re.capturedTexts();
+                           QRegularExpressionMatch reMatch = re.match(lineTmp);
+                           if (reMatch.hasMatch()) {
+                             QStringList cap = reMatch.capturedTexts();
 
                              if (txt) {
                                out << "\"" << cap[3] << "\"" << '\n';

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -299,7 +299,7 @@ QStringList GetDefaultOptionsList(const QString &settingsOptions) {
     // arg2" --option-3 arg3 should generate "--option-1" "--option-2=\"arg1
     // arg2\"" "--option-3" "arg3"
     for (QString arg :
-         defaultOptions.split(QRegExp(" (?=[^\"]*(\"[^\"]*\"[^\"]*)*$)"))) {
+         defaultOptions.split(QRegularExpression(" (?=[^\"]*(\"[^\"]*\"[^\"]*)*$)"))) {
       if (!arg.isEmpty()) {
         defaultOptionsList << arg.replace("\"", "");
       }
@@ -347,8 +347,8 @@ QDir GetConfigDir() {
 
   } else {
     // get data location folder from Qt  - OS dependend
-    outputDir =
-        QDir(QStandardPaths::writableLocation(QStandardPaths::DataLocation));
+    outputDir = QDir(
+        QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation));
   }
 
   //  if (!outputDir.exists()) {


### PR DESCRIPTION
Migrate from Qt 5 to Qt 6 to support Apple Silicon, Windows ARM and better HighDPI support.

- Updated AppVeyor and Travis CI configurations to use Visual Studio 2022 and Qt 6, reflecting the removal of 32-bit Windows desktop kits.
- Adjusted CMakeLists.txt to find and link against Qt 6 components, ensuring compatibility with the new version.
- Revised README and build scripts to reflect updated dependencies and installation instructions for Qt 6.
- Enhanced GitHub Actions workflows to support ARM64 builds and improved artifact handling.
- Replaced deprecated QRegExp with QRegularExpression in the codebase for better regex handling.
- Updated notification sound handling to utilize QSoundEffect from the Multimedia module when available.